### PR TITLE
Potential fix for code scanning alert no. 5: Unsafe jQuery plugin

### DIFF
--- a/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -686,7 +686,7 @@ $.extend( $.validator, {
 		},
 
 		clean: function( selector ) {
-			return $( selector )[ 0 ];
+			return $( this.escapeCssMeta(selector) )[ 0 ];
 		},
 
 		errors: function() {
@@ -1083,7 +1083,7 @@ $.extend( $.validator, {
 			}
 
 			// Always apply ignore filter
-			return $( element ).not( this.settings.ignore )[ 0 ];
+			return $( this.escapeCssMeta(element) ).not( this.settings.ignore )[ 0 ];
 		},
 
 		checkable: function( element ) {


### PR DESCRIPTION
Potential fix for [https://github.com/bogdandelcea/UCVstudents/security/code-scanning/5](https://github.com/bogdandelcea/UCVstudents/security/code-scanning/5)

To fix the problem, we need to ensure that all user inputs are properly sanitized before being used in jQuery selectors. This can be achieved by consistently using the `escapeCssMeta` function to escape any special characters in the input. Specifically, we need to modify the `validationTargetFor` and `clean` functions to use `escapeCssMeta` before using the input in jQuery selectors.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
